### PR TITLE
fix: allow to import `pagination` css

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -67,7 +67,6 @@ export default defineNuxtModule<SwiperModuleOptions>({
           'autoplay',
           'controller',
           'effect-coverflow',
-          'pagination',
           'hash-navigation',
           'history',
           'keyboard',


### PR DESCRIPTION
Before this update i can`t see pagination bars.
The pagination CSS is necessary like we see in documentation page:

https://swiperjs.com/vue#usage
