### PR TITLE
Separating Swiper into chunks from entry bundle

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -2,7 +2,8 @@ import * as swiper from 'swiper'
 import {
   defineNuxtModule,
   addPluginTemplate,
-  addImports
+  addImports,
+  extendViteConfig
 } from '@nuxt/kit'
 import { name, version } from '../package.json'
 
@@ -35,6 +36,19 @@ export default defineNuxtModule<SwiperModuleOptions>({
         from: 'swiper/vue'
       }
     ]
+
+    // Separating Swiper into chunks from Nuxt entry bundle
+    extendViteConfig((viteConfig) => {
+      if (viteConfig.build?.rollupOptions?.manualChunks) {
+        return
+      }
+
+      viteConfig.build!.rollupOptions!.manualChunks = function (id) {
+        if (id.includes('/node_modules/swiper')) {
+          return `vendor-swiper`
+        }
+      }
+    })
 
     // Import Each Swiper Module & CSS if it exists.
     for (const [key, _] of Object.entries(swiper)) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -37,15 +37,19 @@ export default defineNuxtModule<SwiperModuleOptions>({
       }
     ]
 
-    // Separating Swiper into chunks from Nuxt entry bundle
-    extendViteConfig((viteConfig) => {
-      if (viteConfig.build?.rollupOptions?.manualChunks) {
-        return
-      }
+    // Add Manual Chunks for Swiper for Vite.
+    // for a more optimized build.
+    extendViteConfig((config) => {
+      config.build = config.build || {}
+      config.build.rollupOptions = config.build.rollupOptions || {}
+      config.build.rollupOptions.output = config.build.rollupOptions.output || {}
 
-      viteConfig.build!.rollupOptions!.manualChunks = function (id) {
-        if (id.includes('/node_modules/swiper')) {
-          return `vendor-swiper`
+      config.build.rollupOptions.output = {
+        ...config.build.rollupOptions.output,
+        manualChunks: (id) => {
+          if (id.includes('/node_modules/swiper')) {
+            return 'swiper'
+          }
         }
       }
     })


### PR DESCRIPTION
Swiper is a relatively large library. When compiling Nuxt, it increases the main entry.js by about 200kb, entry.css by about 100kb. With this modification, swiper will be separated into its own chunk, improving the loading speed of the application.

This is a POC, it is necessary to deal with situations where the developer will set his own rules for manualChunks, because this solution will override.