### PR TITLE
Add css properly using push, instead of destruct the css array

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -105,7 +105,7 @@ export default defineNuxtModule<ModuleOptions>({
     addImports(moduleImports)
 
     // Add CSS Imports to the nuxt option.
-    nuxt.options.css = [...nuxt.options.css, ...cssImports]
+    nuxt.options.css.push(...cssImports)
 
     // Add Manual Chunks for Swiper for Vite.
     // for a more optimized build.


### PR DESCRIPTION
Why this change?

1. It is faster
2. In my application, imports with ```@import url('@/some/directory/my-file.css');```will be broken due to the destruction. With push it is no problem.